### PR TITLE
Remove default browser border on images

### DIFF
--- a/src/scss/_content.scss
+++ b/src/scss/_content.scss
@@ -5,6 +5,7 @@
 	color: $o-techdocs-color-charcoal;
 	font-size: 15px;
 	line-height: 1.5;
+
 	a {
 		color: oColorsGetColorFor(link, text);
 	}
@@ -117,6 +118,7 @@
 	}
 	pre.cli {
 		background: $o-techdocs-color-charcoal;
+
 		kbd,
 		output {
 			padding-left: 15px;
@@ -140,6 +142,7 @@
 	img {
 		max-width: 100%;
 		height: auto;
+		border: 0;
 	}
 
 	> .alert-big,
@@ -158,6 +161,7 @@
 		overflow: hidden;
 		border-left: 5px solid oColorsGetPaletteColor(claret);
 		background-color: $o-techdocs-color-grey1;
+
 		> h4,
 		> h5 {
 			color: oColorsGetPaletteColor(claret);

--- a/src/scss/_content.scss
+++ b/src/scss/_content.scss
@@ -142,6 +142,8 @@
 	img {
 		max-width: 100%;
 		height: auto;
+	}
+	a img {
 		border: 0;
 	}
 


### PR DESCRIPTION
In IE, default browser styles include a 2px border around all images