### PR TITLE
Fix spacing around border in the footer

### DIFF
--- a/src/scss/_page.scss
+++ b/src/scss/_page.scss
@@ -25,14 +25,14 @@
 	margin-top: 20px;
 	padding-top: 10px;
 	padding-bottom: 10px;
+	border-top: 1px dotted $o-techdocs-color-grey3;
 
 	p {
-		margin: 0.7em 0;
+		margin: 0 0 10px;
 	}
 }
 .o-techdocs-footer__inner {
 	@include oGridColumn(full-width);
-	border-top: 1px dotted $o-techdocs-color-grey3;
 }
 .o-techdocs-footer__secondary {
 	float: right;


### PR DESCRIPTION
### Before

Logo on the right is too close from the border.

![screenshot 2015-03-31 10 39 53](https://cloud.githubusercontent.com/assets/85783/6916231/7c310476-d792-11e4-8c3e-51f22341d194.png)


### After

Adds space between the border and the logo

![screenshot 2015-03-31 10 40 36](https://cloud.githubusercontent.com/assets/85783/6916234/7ead25c2-d792-11e4-9e85-e32872ed920e.png)
