### PR TITLE
Hide menus on page load

### DIFF
--- a/src/js/nav.js
+++ b/src/js/nav.js
@@ -65,6 +65,8 @@ module.exports = function() {
 		}
 	}
 
+	showHideMenu();
+
 	// On scroll, determine which section is in view, and highlight it
 	document.addEventListener('oViewport.scroll', function() {
 		var scrolltop = window.pageYOffset || document.body.scrollTop;


### PR DESCRIPTION
Fixes a bug where the nav would end up being shown at page load when it shouldn't.