### PR TITLE
Change left alignment of nav

### DIFF
--- a/src/scss/_nav.scss
+++ b/src/scss/_nav.scss
@@ -12,7 +12,7 @@
 			position: relative;
 			display: block;
 			overflow: hidden;
-			padding: 6px 10px 6px 30px;
+			padding: 6px 10px 6px 15px;
 			text-overflow: ellipsis;
 			white-space: nowrap;
 			color: oColorsGetColorFor(link, text);
@@ -24,7 +24,7 @@
 	}
 	> li[aria-selected="true"] {
 		> a {
-			padding-left: 15px;
+			padding-left: 0;
 			color: oColorsGetPaletteColor('black');
 			font-weight: bold;
 			pointer-events: none;


### PR DESCRIPTION
So that the highlighted edge of the left nav aligns with the header, this
commit reduces the left padding to 15px.

Before:
![screen shot 2016-01-07 at 13 51 12](https://cloud.githubusercontent.com/assets/68009/12172051/5646e87e-b546-11e5-87b7-eae88f1057f8.png)

![screen shot 2016-01-07 at 13 53 49](https://cloud.githubusercontent.com/assets/68009/12172044/492aeea6-b546-11e5-9ab9-834725559f7b.png)

After:
![screen shot 2016-01-07 at 13 52 01](https://cloud.githubusercontent.com/assets/68009/12172054/5b247c58-b546-11e5-9bce-2bfedfcc8656.png)
![screen shot 2016-01-07 at 13 53 45](https://cloud.githubusercontent.com/assets/68009/12172059/5f9d0372-b546-11e5-9ab5-b7b9aca32156.png)
