### PR TITLE
explicitly include o-grid and fix eslint error

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -1,6 +1,7 @@
 @import 'o-colors/main';
 @import 'src/scss/color-use-cases';
 
+@import 'o-grid/main';
 @import 'o-header/main';
 
 @import 'src/scss/deprecated';

--- a/src/js/nav.js
+++ b/src/js/nav.js
@@ -12,7 +12,7 @@ oViewport.listenTo('resize');
 function nav() {
 	let list = '';
 	const lis = [];
-	let scrollmargin; 
+	let scrollmargin;
 	let headings = [];
 	let currentheading;
 	const qsa = document.querySelectorAll.bind(document);
@@ -125,4 +125,4 @@ function nav() {
 	}, false);
 };
 
-export { nav }
+export { nav };


### PR DESCRIPTION
Closes #48 

Explicitly include `o-grid` as a dependancy.