### PR TITLE
Add o-header

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In moving `o-header` back into `o-techdocs-header` it's possible that we've fail
 
 ## Upgrading from v4.x.x to v5.x.x
 
-o-techdocs v5 relies on o-techdocs-header v4 and o-grid v4.
+o-techdocs v5 relies on o-header v4 and o-grid v4.
 
 ```diff
 +<div class="o-techdocs-container">

--- a/README.md
+++ b/README.md
@@ -8,9 +8,15 @@ It is used in the [Origami registry](http://registry.origami.ft.com), the [image
 
 __o-techdocs__ has no silent mode, so the provided CSS classes beginning with `o-techdocs` must be used. See the demo page for examples.
 
+## Upgrading from v5.x.x to v6.x.x
+
+v6 of `o-techdocs` removes a dependency on `o-header` v4. To upgrade, you'll need to do a find-replace on instances of `o-header` for `o-techdocs-header`.
+
+In moving `o-header` back into `o-techdocs-header` it's possible that we've failed to migrate some features across. If, after updating to v6 and renaming `o-header` to `o-techdocs-header`, you find that things aren't working, please raise an issue.
+
 ## Upgrading from v4.x.x to v5.x.x
 
-o-techdocs v5 relies on o-header v4 and o-grid v4.
+o-techdocs v5 relies on o-techdocs-header v4 and o-grid v4.
 
 ```diff
 +<div class="o-techdocs-container">

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "o-colors": ">=2.5.0 <4",
     "o-grid": "^4.0.0",
-    "o-hierarchical-nav": ">=2.0.0 <4",
+    "o-hierarchical-nav": "^4.0.0",
     "highlight.js": "Financial-Times/highlight.js-shim",
     "o-viewport": ">=1.3.0 <3",
     "ftdomdelegate": ">=1.0.0 <3"

--- a/bower.json
+++ b/bower.json
@@ -2,10 +2,11 @@
   "name": "o-techdocs",
   "dependencies": {
     "o-colors": ">=2.5.0 <4",
-    "o-header": "^4.0.0",
     "o-grid": "^4.0.0",
+    "o-hierarchical-nav": ">=2.0.0 <4",
     "highlight.js": "Financial-Times/highlight.js-shim",
-    "o-viewport": ">=1.3.0 <3"
+    "o-viewport": ">=1.3.0 <3",
+    "ftdomdelegate": ">=1.0.0 <3"
   },
   "main": [
     "main.js",

--- a/demos/src/demo.mustache
+++ b/demos/src/demo.mustache
@@ -1,15 +1,22 @@
 
-<header data-o-component="o-header" class="o-header">
-	<div class="o-header__container">
-		<div class="o-header__inner">
-			<div class="o-header__primary">
-				<div class="o-header__primary__left">
-					<a class="o-header__logo o-header__logo--ft" href="http://www.ft.com">
-						<abbr title="Financial Times">FT</abbr>
-						<h1 class="o-header__title">Documentation title</h1>
-					</a>
-				</div>
+<header data-o-component="o-techdocs-header" class="o-techdocs-header">
+	<div class="o-techdocs-header__container">
+		<div class="o-techdocs-header__primary">
+			<div class="o-techdocs-header__primary__left">
+				<a class="o-techdocs-header__logo" href="/">
+					<span class="origami-logo"></span>
+					<h1 class="o-header__title">Documentation Site</h1>
+				</a>
 			</div>
+
+			<nav class="o-header__primary__right o-hierarchical-nav o-header__nav--primary-theme" data-o-component="o-hierarchical-nav">
+				<ul data-o-hierarchical-nav-level="1"><!--
+				--><li data-priority="1"><a href="#">Demos</a></li><!--
+				--><li data-priority="1"><a href="#">Specification</a></li><!--
+				--><li data-priority="1" aria-selected="true"><a href="#">Documentation</a></li><!--
+				--><li data-more class="o-hierarchical-nav__parent" aria-hidden="true"><a href="#void"><span class="o-hierarchical-nav__more--if-all">Menu<i class="o-hierarchical-nav__parent__down-arrow"></i></span></a></li><!--
+				--></ul>
+			</nav>
 		</div>
 	</div>
 </header>

--- a/demos/src/demo.mustache
+++ b/demos/src/demo.mustache
@@ -5,11 +5,11 @@
 			<div class="o-techdocs-header__primary__left">
 				<a class="o-techdocs-header__logo" href="/">
 					<span class="origami-logo"></span>
-					<h1 class="o-header__title">Documentation Site</h1>
+					<h1 class="o-techdocs-header__title">Documentation Site</h1>
 				</a>
 			</div>
 
-			<nav class="o-header__primary__right o-hierarchical-nav o-header__nav--primary-theme" data-o-component="o-hierarchical-nav">
+			<nav class="o-techdocs-header__primary__right o-hierarchical-nav o-techdocs-header__nav--primary-theme" data-o-component="o-hierarchical-nav">
 				<ul data-o-hierarchical-nav-level="1"><!--
 				--><li data-priority="1"><a href="#">Demos</a></li><!--
 				--><li data-priority="1"><a href="#">Specification</a></li><!--

--- a/main.js
+++ b/main.js
@@ -1,4 +1,3 @@
-require('o-header');
 
 import highlight from './src/js/highlight';
 import { nav } from './src/js/nav';
@@ -6,6 +5,7 @@ import { tables } from './src/js/tables';
 import { reveals } from './src/js/reveals';
 import { permalinks } from './src/js/permalinks';
 import { gistIt } from './src/js/gist-it';
+import { Header } from './src/js/Header';
 
 const techdocsModules = [
 	highlight,
@@ -20,6 +20,7 @@ function init() {
 	techdocsModules.forEach(function(module) {
 		module();
 	});
+	Header.init();
 }
 
 document.addEventListener('o.DOMContentLoaded', init, false);

--- a/main.scss
+++ b/main.scss
@@ -2,8 +2,7 @@
 @import 'src/scss/color-use-cases';
 
 @import 'o-grid/main';
-@import 'o-header/main';
-@import "o-hierarchical-nav/main";
+@import 'o-hierarchical-nav/main';
 
 @import 'src/scss/deprecated';
 @import 'src/scss/mixins';

--- a/main.scss
+++ b/main.scss
@@ -3,6 +3,7 @@
 
 @import 'o-grid/main';
 @import 'o-header/main';
+@import "o-hierarchical-nav/main";
 
 @import 'src/scss/deprecated';
 @import 'src/scss/mixins';
@@ -13,3 +14,7 @@
 @import 'src/scss/table';
 @import 'src/scss/card';
 @import 'src/scss/solarized-light.hljs-theme';
+@import 'src/scss/header_mixins';
+@import 'src/scss/header';
+@import 'src/scss/header_icon';
+@import 'src/scss/header_theme_primary';

--- a/src/js/Header.js
+++ b/src/js/Header.js
@@ -1,0 +1,75 @@
+/*global require,module*/
+
+const DomDelegate = require('ftdomdelegate');
+const HierarchicalNav = require('o-hierarchical-nav');
+
+function Header(rootEl) {
+
+	let bodyDelegate;
+	// Gets all nav elements in the header
+	const hierarchicalNavEls = [
+			rootEl.querySelector('.o-header__nav--primary-theme'),
+			rootEl.querySelector('.o-header__nav--secondary-theme'),
+			rootEl.querySelector('.o-header__nav--tools-theme')
+		].filter(function(el) {
+			/**
+			 * Overflow is hidden by default on the tools and primary theme for it to resize properly on core experience
+			 * where level 2 and 3 menus won't appear anyway, but in primary experience they do need to appear. We do this
+			 * here instead of the map function in init because this needs to be applied regardless of the nav having been
+			 * initialized previously, like when the o.DOMContententLoaded event is dispatched
+			 */
+			if (el) {
+				el.style.overflow = 'visible';
+			}
+			return el && el.nodeType === 1 && !el.hasAttribute('data-o-hierarchical-nav--js');
+		});
+	let hierarchicalNavs = [];
+
+	function init() {
+		if (!rootEl) {
+			rootEl = document.body;
+		} else if (!(rootEl instanceof HTMLElement)) {
+			rootEl = document.querySelector(rootEl);
+		}
+		rootEl.setAttribute('data-o-header--js', '');
+		bodyDelegate = new DomDelegate(document.body);
+		hierarchicalNavs = hierarchicalNavEls.map(function(el) {
+			return new HierarchicalNav(el);
+		});
+	}
+
+	// Release header and all its navs from memory
+	function destroy() {
+		bodyDelegate.destroy();
+		for (let c = 0, l = hierarchicalNavs.length; c < l; c++) {
+			if (hierarchicalNavs[c]) {
+				hierarchicalNavs[c].destroy();
+			}
+		}
+		rootEl.removeAttribute('data-o-header--js');
+	}
+
+	init();
+
+	this.destroy = destroy;
+
+}
+
+// Initializes all header elements in the page or whatever element is passed to it
+Header.init = function(el) {
+	if (!el) {
+		el = document.body;
+	} else if (!(el instanceof HTMLElement)) {
+		el = document.querySelector(el);
+	}
+	const headerEls = el.querySelectorAll('[data-o-component="o-header"]');
+	const headers = [];
+	for (let c = 0, l = headerEls.length; c < l; c++) {
+		if (!headerEls[c].hasAttribute('data-o-header--js')) {
+			headers.push(new Header(headerEls[c]));
+		}
+	}
+	return headers;
+};
+
+module.exports = { Header };

--- a/src/js/Header.js
+++ b/src/js/Header.js
@@ -8,9 +8,9 @@ function Header(rootEl) {
 	let bodyDelegate;
 	// Gets all nav elements in the header
 	const hierarchicalNavEls = [
-			rootEl.querySelector('.o-header__nav--primary-theme'),
-			rootEl.querySelector('.o-header__nav--secondary-theme'),
-			rootEl.querySelector('.o-header__nav--tools-theme')
+			rootEl.querySelector('.o-techdocs-header__nav--primary-theme'),
+			rootEl.querySelector('.o-techdocs-header__nav--secondary-theme'),
+			rootEl.querySelector('.o-techdocs-header__nav--tools-theme')
 		].filter(function(el) {
 			/**
 			 * Overflow is hidden by default on the tools and primary theme for it to resize properly on core experience
@@ -31,7 +31,7 @@ function Header(rootEl) {
 		} else if (!(rootEl instanceof HTMLElement)) {
 			rootEl = document.querySelector(rootEl);
 		}
-		rootEl.setAttribute('data-o-header--js', '');
+		rootEl.setAttribute('data-o-techdocs-header--js', '');
 		bodyDelegate = new DomDelegate(document.body);
 		hierarchicalNavs = hierarchicalNavEls.map(function(el) {
 			return new HierarchicalNav(el);
@@ -46,7 +46,7 @@ function Header(rootEl) {
 				hierarchicalNavs[c].destroy();
 			}
 		}
-		rootEl.removeAttribute('data-o-header--js');
+		rootEl.removeAttribute('data-o-techdocs-header--js');
 	}
 
 	init();
@@ -62,10 +62,10 @@ Header.init = function(el) {
 	} else if (!(el instanceof HTMLElement)) {
 		el = document.querySelector(el);
 	}
-	const headerEls = el.querySelectorAll('[data-o-component="o-header"]');
+	const headerEls = el.querySelectorAll('[data-o-component="o-techdocs-header"]');
 	const headers = [];
 	for (let c = 0, l = headerEls.length; c < l; c++) {
-		if (!headerEls[c].hasAttribute('data-o-header--js')) {
+		if (!headerEls[c].hasAttribute('data-o-techdocs-header--js')) {
 			headers.push(new Header(headerEls[c]));
 		}
 	}

--- a/src/scss/_color-use-cases.scss
+++ b/src/scss/_color-use-cases.scss
@@ -1,3 +1,6 @@
+@include oColorsSetUseCase(o-header, background, 'grey-tint5');
+@include oColorsSetUseCase(o-header-item, text, 'white');
+
 @include oColorsSetUseCase(product-brand, background, 'blue');
 
 @include oColorsSetUseCase(o-techdocs-block-code-sample, background, 'pink-tint1');

--- a/src/scss/_color-use-cases.scss
+++ b/src/scss/_color-use-cases.scss
@@ -1,5 +1,5 @@
-@include oColorsSetUseCase(o-header, background, 'grey-tint5');
-@include oColorsSetUseCase(o-header-item, text, 'white');
+@include oColorsSetUseCase(o-techdocs-header, background, 'grey-tint5');
+@include oColorsSetUseCase(o-techdocs-header-item, text, 'white');
 
 @include oColorsSetUseCase(product-brand, background, 'blue');
 

--- a/src/scss/_header.scss
+++ b/src/scss/_header.scss
@@ -1,0 +1,258 @@
+// Container widths that products can modify
+
+/// Left primary zone width
+/// @type {Number}
+$o-header-primary-left-width: (default: 244px, M: 303px) !default;
+
+/// Left secondary zone width
+/// @type {Number}
+$o-header-secondary-left-width: 150px !default;
+
+/// Primary featured zone width
+/// @type {Number}
+$o-header-primary-featured-width: 160px !default;
+
+/// Breakpoint at which the header layout changes significantly
+$o-header-breakpoint: M !default;
+
+.o-header {
+	min-height: 55px;
+	max-height: 125px;
+	background: oColorsGetColorFor(o-header, background);
+	// Workaround so the brand colour goes to full width in XL screens
+	background-image: linear-gradient(to bottom, transparent 50px, oColorsGetColorFor(o-header-product-brand product-brand, background) 20px);
+	// Prevents flashes of text in Safari when items are hovered and opacity varies
+	-webkit-font-smoothing: antialiased;
+
+	a {
+		text-decoration: none;
+	}
+	[aria-hidden=true] {
+		display: none;
+	}
+}
+
+.o-header--tall {
+	@include _oHeaderBreakpoint {
+		min-height: 85px;
+		background-image: linear-gradient(to bottom, transparent 80px, oColorsGetColorFor(o-header-product-brand product-brand, background) 20px);
+	}
+}
+
+// Container for primary and secondary that sets the width of these using o-grid
+.o-header__container {
+	@include oGridContainer;
+	position: relative;
+	color: oColorsGetColorFor(o-header-item, text);
+
+	a {
+		color: oColorsGetColorFor(o-header-item, text);
+
+		&:focus,
+		&:hover {
+			color: oColorsGetColorFor(o-header-item, text);
+			opacity: 0.7;
+		}
+	}
+
+	// We need mega-dropdowns to also have the same gutters as the container
+	.o-hierarchical-nav__mega-dropdown {
+		right: oGridGutter();
+		left: oGridGutter();
+		width: auto;
+
+		@include _oHeaderBreakpoint {
+			right: oGridGutter($o-header-breakpoint);
+			left: oGridGutter($o-header-breakpoint);
+		}
+	}
+
+	// Give a minimum width to submenus
+	[data-o-hierarchical-nav-level] {
+		min-width: 100%;
+		box-sizing: border-box;
+	}
+
+	// Ensure passing from normal to expanded state
+	// doesn't change the width of the menu
+	.o-hierarchical-nav__parent__right-arrow,
+	.o-hierarchical-nav__parent__down-arrow {
+		box-sizing: border-box;
+		width: 16px;
+		text-align: right;
+		padding-right: 6px;
+		line-height: 16px;
+	}
+}
+
+// Alternative to the FT masthead
+.o-header__title {
+	display: inline-block;
+	margin: 0;
+	padding: 0;
+	font-weight: normal;
+	font-size: 20px;
+	line-height: 40px;
+	white-space: nowrap;
+	vertical-align: top;
+
+	@include _oHeaderBreakpoint {
+		font-size: 24px;
+
+		.o-header--tall & {
+			line-height: 60px;
+		}
+	}
+}
+
+// Default tagline styling
+.o-header__tagline {
+	font-weight: normal;
+	margin: 0;
+	white-space: nowrap;
+	// Default behaviour for when there's not enough space because we don't know the
+	// width of the tagline
+	text-overflow: ellipsis;
+	overflow: hidden;
+}
+
+// Primary container
+.o-header__primary {
+	display: table;
+	table-layout: fixed;
+	width: 100%;
+	height: 50px;
+
+	// Adapted tagline style for primary container
+	.o-header__tagline {
+		font-size: 16px;
+		line-height: 50px;
+		margin-left: oGridGutter();
+		margin-right: oGridGutter() * 2;
+		text-align: right;
+	}
+
+	.o-header--tall & {
+		@include _oHeaderBreakpoint {
+			height: 80px;
+
+			.o-header__tagline {
+				line-height: 80px;
+			}
+		}
+	}
+}
+
+// Inner containers for the primary container
+.o-header__primary__left,
+.o-header__primary__center,
+.o-header__primary__right,
+.o-header__primary__featured,
+.o-header__secondary__left,
+.o-header__secondary__right {
+	display: table-cell;
+	vertical-align: middle;
+}
+.o-header__primary__left {
+	@if type-of($o-header-primary-left-width) == map {
+		@each $layout-name, $header-primary-left-width in $o-header-primary-left-width {
+			@if $layout-name == default {
+				width: $header-primary-left-width;
+			} @else {
+				@include oGridRespondTo($layout-name) {
+					width: $header-primary-left-width;
+				}
+			}
+			@if $layout-name == $o-grid-fixed-layout {
+				@include oGridTargetIE8 {
+					width: $header-primary-left-width;
+				}
+			}
+		}
+	}
+	@if type-of($o-header-primary-left-width) == number {
+		width: $o-header-primary-left-width;
+	}
+}
+.o-header__primary__right {
+	position: relative;
+	right: oGridGutter() * -1;
+
+	@include _oHeaderBreakpoint {
+		right: 0;
+	}
+}
+.o-header__primary__featured {
+	// scss-lint:disable DeclarationOrder
+	display: none;
+	padding-left: oGridGutter();
+
+	img {
+		border: 0;
+	}
+
+	@include _oHeaderBreakpoint {
+		display: table-cell;
+		padding-left: oGridGutter($o-header-breakpoint);
+	}
+
+	@if type-of($o-header-primary-featured-width) == map {
+		@each $layout-name, $header-primary-featured-width in $o-header-primary-featured-width {
+			@if $layout-name == default {
+				width: $header-primary-featured-width;
+			} @else {
+				@include oGridRespondTo($layout-name) {
+					width: $header-primary-featured-width;
+				}
+			}
+			@if $layout-name == $o-grid-fixed-layout {
+				@include oGridTargetIE8 {
+					width: $header-primary-featured-width;
+				}
+			}
+		}
+	}
+	@if type-of($o-header-primary-featured-width) == number {
+		width: $o-header-primary-featured-width;
+	}
+}
+
+// Secondary container
+.o-header__secondary {
+	background-color: oColorsGetColorFor(o-header-product-brand product-brand, background);
+	display: table;
+	table-layout: fixed;
+	width: 100%;
+	// Force a minimum 5px height for an empty secondary element
+	height: 5px;
+	max-height: 25px;
+
+	// Adapted tagline for secondary container
+	.o-header__tagline {
+		font-size: 14px;
+		line-height: 25px;
+	}
+}
+
+// Inner containers for the secondary container
+.o-header__secondary__left {
+	@if type-of($o-header-secondary-left-width) == map {
+		@each $layout-name, $header-secondary-left-width in $o-header-secondary-left-width {
+			@if $layout-name == default {
+				width: $header-secondary-left-width;
+			} @else {
+				@include oGridRespondTo($layout-name) {
+					width: $header-secondary-left-width;
+				}
+			}
+			@if $layout-name == $o-grid-fixed-layout {
+				@include oGridTargetIE8 {
+					width: $header-secondary-left-width;
+				}
+			}
+		}
+	}
+	@if type-of($o-header-secondary-left-width) == number {
+		width: $o-header-secondary-left-width;
+	}
+}

--- a/src/scss/_header.scss
+++ b/src/scss/_header.scss
@@ -72,17 +72,6 @@ $o-techdocs-header-breakpoint: M !default;
 		min-width: 100%;
 		box-sizing: border-box;
 	}
-
-	// Ensure passing from normal to expanded state
-	// doesn't change the width of the menu
-	.o-hierarchical-nav__parent__right-arrow,
-	.o-hierarchical-nav__parent__down-arrow {
-		box-sizing: border-box;
-		width: 16px;
-		text-align: right;
-		padding-right: 6px;
-		line-height: 16px;
-	}
 }
 
 // Alternative to the FT masthead

--- a/src/scss/_header.scss
+++ b/src/scss/_header.scss
@@ -2,25 +2,25 @@
 
 /// Left primary zone width
 /// @type {Number}
-$o-header-primary-left-width: (default: 244px, M: 303px) !default;
+$o-techdocs-header-primary-left-width: (default: 244px, M: 303px) !default;
 
 /// Left secondary zone width
 /// @type {Number}
-$o-header-secondary-left-width: 150px !default;
+$o-techdocs-header-secondary-left-width: 150px !default;
 
 /// Primary featured zone width
 /// @type {Number}
-$o-header-primary-featured-width: 160px !default;
+$o-techdocs-header-primary-featured-width: 160px !default;
 
 /// Breakpoint at which the header layout changes significantly
-$o-header-breakpoint: M !default;
+$o-techdocs-header-breakpoint: M !default;
 
-.o-header {
+.o-techdocs-header {
 	min-height: 55px;
 	max-height: 125px;
-	background: oColorsGetColorFor(o-header, background);
+	background: oColorsGetColorFor(o-techdocs-header, background);
 	// Workaround so the brand colour goes to full width in XL screens
-	background-image: linear-gradient(to bottom, transparent 50px, oColorsGetColorFor(o-header-product-brand product-brand, background) 20px);
+	background-image: linear-gradient(to bottom, transparent 50px, oColorsGetColorFor(o-techdocs-header-product-brand product-brand, background) 20px);
 	// Prevents flashes of text in Safari when items are hovered and opacity varies
 	-webkit-font-smoothing: antialiased;
 
@@ -32,25 +32,25 @@ $o-header-breakpoint: M !default;
 	}
 }
 
-.o-header--tall {
-	@include _oHeaderBreakpoint {
+.o-techdocs-header--tall {
+	@include _oTechdocsHeaderBreakpoint {
 		min-height: 85px;
-		background-image: linear-gradient(to bottom, transparent 80px, oColorsGetColorFor(o-header-product-brand product-brand, background) 20px);
+		background-image: linear-gradient(to bottom, transparent 80px, oColorsGetColorFor(o-techdocs-header-product-brand product-brand, background) 20px);
 	}
 }
 
 // Container for primary and secondary that sets the width of these using o-grid
-.o-header__container {
+.o-techdocs-header__container {
 	@include oGridContainer;
 	position: relative;
-	color: oColorsGetColorFor(o-header-item, text);
+	color: oColorsGetColorFor(o-techdocs-header-item, text);
 
 	a {
-		color: oColorsGetColorFor(o-header-item, text);
+		color: oColorsGetColorFor(o-techdocs-header-item, text);
 
 		&:focus,
 		&:hover {
-			color: oColorsGetColorFor(o-header-item, text);
+			color: oColorsGetColorFor(o-techdocs-header-item, text);
 			opacity: 0.7;
 		}
 	}
@@ -61,9 +61,9 @@ $o-header-breakpoint: M !default;
 		left: oGridGutter();
 		width: auto;
 
-		@include _oHeaderBreakpoint {
-			right: oGridGutter($o-header-breakpoint);
-			left: oGridGutter($o-header-breakpoint);
+		@include _oTechdocsHeaderBreakpoint {
+			right: oGridGutter($o-techdocs-header-breakpoint);
+			left: oGridGutter($o-techdocs-header-breakpoint);
 		}
 	}
 
@@ -86,7 +86,7 @@ $o-header-breakpoint: M !default;
 }
 
 // Alternative to the FT masthead
-.o-header__title {
+.o-techdocs-header__title {
 	display: inline-block;
 	margin: 0;
 	padding: 0;
@@ -96,17 +96,17 @@ $o-header-breakpoint: M !default;
 	white-space: nowrap;
 	vertical-align: top;
 
-	@include _oHeaderBreakpoint {
+	@include _oTechdocsHeaderBreakpoint {
 		font-size: 24px;
 
-		.o-header--tall & {
+		.o-techdocs-header--tall & {
 			line-height: 60px;
 		}
 	}
 }
 
 // Default tagline styling
-.o-header__tagline {
+.o-techdocs-header__tagline {
 	font-weight: normal;
 	margin: 0;
 	white-space: nowrap;
@@ -117,14 +117,14 @@ $o-header-breakpoint: M !default;
 }
 
 // Primary container
-.o-header__primary {
+.o-techdocs-header__primary {
 	display: table;
 	table-layout: fixed;
 	width: 100%;
 	height: 50px;
 
 	// Adapted tagline style for primary container
-	.o-header__tagline {
+	.o-techdocs-header__tagline {
 		font-size: 16px;
 		line-height: 50px;
 		margin-left: oGridGutter();
@@ -132,11 +132,11 @@ $o-header-breakpoint: M !default;
 		text-align: right;
 	}
 
-	.o-header--tall & {
-		@include _oHeaderBreakpoint {
+	.o-techdocs-header--tall & {
+		@include _oTechdocsHeaderBreakpoint {
 			height: 80px;
 
-			.o-header__tagline {
+			.o-techdocs-header__tagline {
 				line-height: 80px;
 			}
 		}
@@ -144,18 +144,18 @@ $o-header-breakpoint: M !default;
 }
 
 // Inner containers for the primary container
-.o-header__primary__left,
-.o-header__primary__center,
-.o-header__primary__right,
-.o-header__primary__featured,
-.o-header__secondary__left,
-.o-header__secondary__right {
+.o-techdocs-header__primary__left,
+.o-techdocs-header__primary__center,
+.o-techdocs-header__primary__right,
+.o-techdocs-header__primary__featured,
+.o-techdocs-header__secondary__left,
+.o-techdocs-header__secondary__right {
 	display: table-cell;
 	vertical-align: middle;
 }
-.o-header__primary__left {
-	@if type-of($o-header-primary-left-width) == map {
-		@each $layout-name, $header-primary-left-width in $o-header-primary-left-width {
+.o-techdocs-header__primary__left {
+	@if type-of($o-techdocs-header-primary-left-width) == map {
+		@each $layout-name, $header-primary-left-width in $o-techdocs-header-primary-left-width {
 			@if $layout-name == default {
 				width: $header-primary-left-width;
 			} @else {
@@ -170,19 +170,19 @@ $o-header-breakpoint: M !default;
 			}
 		}
 	}
-	@if type-of($o-header-primary-left-width) == number {
-		width: $o-header-primary-left-width;
+	@if type-of($o-techdocs-header-primary-left-width) == number {
+		width: $o-techdocs-header-primary-left-width;
 	}
 }
-.o-header__primary__right {
+.o-techdocs-header__primary__right {
 	position: relative;
 	right: oGridGutter() * -1;
 
-	@include _oHeaderBreakpoint {
+	@include _oTechdocsHeaderBreakpoint {
 		right: 0;
 	}
 }
-.o-header__primary__featured {
+.o-techdocs-header__primary__featured {
 	// scss-lint:disable DeclarationOrder
 	display: none;
 	padding-left: oGridGutter();
@@ -191,13 +191,13 @@ $o-header-breakpoint: M !default;
 		border: 0;
 	}
 
-	@include _oHeaderBreakpoint {
+	@include _oTechdocsHeaderBreakpoint {
 		display: table-cell;
-		padding-left: oGridGutter($o-header-breakpoint);
+		padding-left: oGridGutter($o-techdocs-header-breakpoint);
 	}
 
-	@if type-of($o-header-primary-featured-width) == map {
-		@each $layout-name, $header-primary-featured-width in $o-header-primary-featured-width {
+	@if type-of($o-techdocs-header-primary-featured-width) == map {
+		@each $layout-name, $header-primary-featured-width in $o-techdocs-header-primary-featured-width {
 			@if $layout-name == default {
 				width: $header-primary-featured-width;
 			} @else {
@@ -212,14 +212,14 @@ $o-header-breakpoint: M !default;
 			}
 		}
 	}
-	@if type-of($o-header-primary-featured-width) == number {
-		width: $o-header-primary-featured-width;
+	@if type-of($o-techdocs-header-primary-featured-width) == number {
+		width: $o-techdocs-header-primary-featured-width;
 	}
 }
 
 // Secondary container
-.o-header__secondary {
-	background-color: oColorsGetColorFor(o-header-product-brand product-brand, background);
+.o-techdocs-header__secondary {
+	background-color: oColorsGetColorFor(o-techdocs-header-product-brand product-brand, background);
 	display: table;
 	table-layout: fixed;
 	width: 100%;
@@ -228,16 +228,16 @@ $o-header-breakpoint: M !default;
 	max-height: 25px;
 
 	// Adapted tagline for secondary container
-	.o-header__tagline {
+	.o-techdocs-header__tagline {
 		font-size: 14px;
 		line-height: 25px;
 	}
 }
 
 // Inner containers for the secondary container
-.o-header__secondary__left {
-	@if type-of($o-header-secondary-left-width) == map {
-		@each $layout-name, $header-secondary-left-width in $o-header-secondary-left-width {
+.o-techdocs-header__secondary__left {
+	@if type-of($o-techdocs-header-secondary-left-width) == map {
+		@each $layout-name, $header-secondary-left-width in $o-techdocs-header-secondary-left-width {
 			@if $layout-name == default {
 				width: $header-secondary-left-width;
 			} @else {
@@ -252,7 +252,7 @@ $o-header-breakpoint: M !default;
 			}
 		}
 	}
-	@if type-of($o-header-secondary-left-width) == number {
-		width: $o-header-secondary-left-width;
+	@if type-of($o-techdocs-header-secondary-left-width) == number {
+		width: $o-techdocs-header-secondary-left-width;
 	}
 }

--- a/src/scss/_header_icon.scss
+++ b/src/scss/_header_icon.scss
@@ -1,14 +1,14 @@
 // Default styling for logos used in the header and its container
-.o-header__logo,
-.o-header__logo > img,
-.o-header__logo > a,
-.o-header__ft-masthead {
+.o-techdocs-header__logo,
+.o-techdocs-header__logo > img,
+.o-techdocs-header__logo > a,
+.o-techdocs-header__ft-masthead {
 	display: inline-block;
 	vertical-align: middle;
 }
 
 // Styling for the FT logo
-.o-header__logo--ft {
+.o-techdocs-header__logo--ft {
 	display: block;
 
 	> a {
@@ -16,7 +16,7 @@
 	}
 
 	abbr {
-		background: url(oHeaderAsset('img/ft-logo-40.png')) no-repeat;
+		background: url(oTechdocsHeaderAsset('img/ft-logo-40.png')) no-repeat;
 		background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0MCIgaGVpZ2h0PSI0MCIgdmlld0JveD0iMCAwIDI1NiAyNTYiPjxsaW5lYXJHcmFkaWVudCBpZD0iYSIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiIHgxPSIxMjcuOTk5IiB4Mj0iMTI3Ljk5OSIgeTI9IjI1NiI+PHN0b3Agb2Zmc2V0PSIwIiBzdG9wLWNvbG9yPSIjRkZFOENGIi8+PHN0b3Agb2Zmc2V0PSIxIiBzdG9wLWNvbG9yPSIjRkZEREI5Ii8+PC9saW5lYXJHcmFkaWVudD48cGF0aCBmaWxsPSJ1cmwoI2EpIiBkPSJNMCAwaDI1NnYyNTZoLTI1NnoiLz48cGF0aCBmaWxsPSIjMzMzIiBkPSJNNjUuNDcxIDEzMy42MDNjMCAxMi4wODEgMy4yMjUgMTMuNDM5IDE3LjAwMSAxMy45NTJ2NC40MjFoLTU0Ljc1NHYtNC40MjFjMTEuMzkzLS41MTMgMTQuNjIxLTEuODcxIDE0LjYyMS0xMy45NTJ2LTc4Ljg4OGMwLTEyLjA5Mi0zLjIyOS0xMy40NDktMTQuMjgxLTEzLjk1NHYtNC40MjJoOTYuNThsLjY4OCAyNS41MDVoLTQuNzYyYy00LjA4My0xMi45MjQtOC41MDctMTctMzEuMTIzLTE3aC0xNy41MTljLTUuMjYyIDAtNi40NTEgMS4xODMtNi40NTEgNS45NXYzNi41NjVoOC42MjhjMTguMDI5IDAgMjEuOTQyLTMuMjQgMjQuMTUtMTUuMzE1aDQuNDJ2NDAuODE0aC00LjQyYy0yLjM3OC0xMy42MDQtOS4xODQtMTcuMDAyLTI0LjE1LTE3LjAwMmgtOC42Mjh2MzcuNzQ3ek0yMzQuMDA3IDM2LjMzOWgtMTAxLjM0OGwtMi4zNTQgMjUuNTE0aDUuODFjMy43MTMtMTIuNDk3IDkuMTctMTcuMDA4IDIxLjM2OS0xNy4wMDhoMTQuMjg0djg4Ljc1OGMwIDEyLjA4MS0zLjIzIDEzLjQzOS0xNi4zMjMgMTMuOTUydjQuNDIxaDU1Ljc3OXYtNC40MjFjLTEzLjA5Ni0uNTEzLTE2LjMyNy0xLjg3MS0xNi4zMjctMTMuOTUydi04OC43NTloMTQuMjc4YzEyLjIwNiAwIDE3LjY2OSA0LjUxMiAyMS4zNzMgMTcuMDA4aDUuODFsLTIuMzUxLTI1LjUxM3oiLz48L3N2Zz4='), none;
 		background-size: contain;
 		height: 0;
@@ -31,8 +31,8 @@
 		margin-right: oGridGutter();
 	}
 
-	.o-header--tall & {
-		@include _oHeaderBreakpoint {
+	.o-techdocs-header--tall & {
+		@include _oTechdocsHeaderBreakpoint {
 			> a {
 				height: 60px;
 			}
@@ -45,20 +45,20 @@
 		@include oGridTargetIE8 {
 			abbr {
 				// Full size logo
-				background: url(oHeaderAsset('img/ft-logo.png')) no-repeat;
+				background: url(oTechdocsHeaderAsset('img/ft-logo.png')) no-repeat;
 			}
 		}
 	}
 }
 
 // Brand image
-.o-header__logo img {
+.o-techdocs-header__logo img {
 	display: inline-block;
 	max-height: 40px;
 	margin-right: oGridGutter();
 
-	.o-header--tall & {
-		@include _oHeaderBreakpoint {
+	.o-techdocs-header--tall & {
+		@include _oTechdocsHeaderBreakpoint {
 			max-height: 60px;
 		}
 	}
@@ -67,7 +67,7 @@
 // Disabling the declaration order because scss-lint raises a warning
 // for having oGridRespondTo after a child selector
 // scss-lint:disable DeclarationOrder
-.o-header__ft-masthead {
+.o-techdocs-header__ft-masthead {
 	margin: 0;
 	padding: 0;
 	width: 155px;
@@ -75,8 +75,8 @@
 
 	// The actual masthead is a background on the i tag
 	i {
-		background: url(oHeaderAsset('img/ft-masthead.png')) left bottom no-repeat;
-		background-image: url(oHeaderAsset('img/ft-masthead.svg')), none;
+		background: url(oTechdocsHeaderAsset('img/ft-masthead.png')) left bottom no-repeat;
+		background-image: url(oTechdocsHeaderAsset('img/ft-masthead.svg')), none;
 		height: 18px;
 		width: 100%;
 		background-size: 100%;
@@ -85,14 +85,14 @@
 		padding-top: 8px;
 	}
 
-	@include _oHeaderBreakpoint {
+	@include _oTechdocsHeaderBreakpoint {
 		width: 218px;
 
 		i {
 			padding-top: 11px;
 		}
 
-		.o-header--tall & {
+		.o-techdocs-header--tall & {
 			line-height: 60px;
 
 			i {

--- a/src/scss/_header_icon.scss
+++ b/src/scss/_header_icon.scss
@@ -1,0 +1,103 @@
+// Default styling for logos used in the header and its container
+.o-header__logo,
+.o-header__logo > img,
+.o-header__logo > a,
+.o-header__ft-masthead {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+// Styling for the FT logo
+.o-header__logo--ft {
+	display: block;
+
+	> a {
+		height: 40px; // sets vertical aligment for the following elements
+	}
+
+	abbr {
+		background: url(oHeaderAsset('img/ft-logo-40.png')) no-repeat;
+		background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0MCIgaGVpZ2h0PSI0MCIgdmlld0JveD0iMCAwIDI1NiAyNTYiPjxsaW5lYXJHcmFkaWVudCBpZD0iYSIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiIHgxPSIxMjcuOTk5IiB4Mj0iMTI3Ljk5OSIgeTI9IjI1NiI+PHN0b3Agb2Zmc2V0PSIwIiBzdG9wLWNvbG9yPSIjRkZFOENGIi8+PHN0b3Agb2Zmc2V0PSIxIiBzdG9wLWNvbG9yPSIjRkZEREI5Ii8+PC9saW5lYXJHcmFkaWVudD48cGF0aCBmaWxsPSJ1cmwoI2EpIiBkPSJNMCAwaDI1NnYyNTZoLTI1NnoiLz48cGF0aCBmaWxsPSIjMzMzIiBkPSJNNjUuNDcxIDEzMy42MDNjMCAxMi4wODEgMy4yMjUgMTMuNDM5IDE3LjAwMSAxMy45NTJ2NC40MjFoLTU0Ljc1NHYtNC40MjFjMTEuMzkzLS41MTMgMTQuNjIxLTEuODcxIDE0LjYyMS0xMy45NTJ2LTc4Ljg4OGMwLTEyLjA5Mi0zLjIyOS0xMy40NDktMTQuMjgxLTEzLjk1NHYtNC40MjJoOTYuNThsLjY4OCAyNS41MDVoLTQuNzYyYy00LjA4My0xMi45MjQtOC41MDctMTctMzEuMTIzLTE3aC0xNy41MTljLTUuMjYyIDAtNi40NTEgMS4xODMtNi40NTEgNS45NXYzNi41NjVoOC42MjhjMTguMDI5IDAgMjEuOTQyLTMuMjQgMjQuMTUtMTUuMzE1aDQuNDJ2NDAuODE0aC00LjQyYy0yLjM3OC0xMy42MDQtOS4xODQtMTcuMDAyLTI0LjE1LTE3LjAwMmgtOC42Mjh2MzcuNzQ3ek0yMzQuMDA3IDM2LjMzOWgtMTAxLjM0OGwtMi4zNTQgMjUuNTE0aDUuODFjMy43MTMtMTIuNDk3IDkuMTctMTcuMDA4IDIxLjM2OS0xNy4wMDhoMTQuMjg0djg4Ljc1OGMwIDEyLjA4MS0zLjIzIDEzLjQzOS0xNi4zMjMgMTMuOTUydjQuNDIxaDU1Ljc3OXYtNC40MjFjLTEzLjA5Ni0uNTEzLTE2LjMyNy0xLjg3MS0xNi4zMjctMTMuOTUydi04OC43NTloMTQuMjc4YzEyLjIwNiAwIDE3LjY2OSA0LjUxMiAyMS4zNzMgMTcuMDA4aDUuODFsLTIuMzUxLTI1LjUxM3oiLz48L3N2Zz4='), none;
+		background-size: contain;
+		height: 0;
+		width: 40px;
+		padding-top: 40px;
+		line-height: 40px;
+		display: inline-block;
+		text-indent: 100%;
+		overflow: hidden;
+		border-bottom: 0;
+		vertical-align: top;
+		margin-right: oGridGutter();
+	}
+
+	.o-header--tall & {
+		@include _oHeaderBreakpoint {
+			> a {
+				height: 60px;
+			}
+			abbr {
+				padding-top: 60px;
+				line-height: 60px;
+				width: 60px;
+			}
+		}
+		@include oGridTargetIE8 {
+			abbr {
+				// Full size logo
+				background: url(oHeaderAsset('img/ft-logo.png')) no-repeat;
+			}
+		}
+	}
+}
+
+// Brand image
+.o-header__logo img {
+	display: inline-block;
+	max-height: 40px;
+	margin-right: oGridGutter();
+
+	.o-header--tall & {
+		@include _oHeaderBreakpoint {
+			max-height: 60px;
+		}
+	}
+}
+
+// Disabling the declaration order because scss-lint raises a warning
+// for having oGridRespondTo after a child selector
+// scss-lint:disable DeclarationOrder
+.o-header__ft-masthead {
+	margin: 0;
+	padding: 0;
+	width: 155px;
+	line-height: 40px;
+
+	// The actual masthead is a background on the i tag
+	i {
+		background: url(oHeaderAsset('img/ft-masthead.png')) left bottom no-repeat;
+		background-image: url(oHeaderAsset('img/ft-masthead.svg')), none;
+		height: 18px;
+		width: 100%;
+		background-size: 100%;
+		display: inline-block;
+		vertical-align: top;
+		padding-top: 8px;
+	}
+
+	@include _oHeaderBreakpoint {
+		width: 218px;
+
+		i {
+			padding-top: 11px;
+		}
+
+		.o-header--tall & {
+			line-height: 60px;
+
+			i {
+				padding-top: 18px;
+			}
+		}
+	}
+}

--- a/src/scss/_header_mixins.scss
+++ b/src/scss/_header_mixins.scss
@@ -1,0 +1,53 @@
+/// Default arrow styling
+///
+/// @param {Number} $size [8px]
+@mixin oHeaderArrow($size: 8px) {
+	border-left: $size solid transparent;
+	border-right: $size solid transparent;
+	width: 0;
+	height: 0;
+	content: ".";
+	text-indent: $size;
+	overflow: hidden;
+	position: absolute;
+}
+
+/// Styles for arrow pointing down
+///
+/// @param {Color} $color [#333333]
+/// @param {Number} $size [8px]
+@mixin oHeaderDownArrow($color: #333333, $size: 8px) {
+	@include oHeaderArrow($size);
+	border-top: $size solid $color;
+	top: 100%;
+	margin-top: -1px; // Extra pixel ensures background and arrow have no space between them
+	left: 50%;
+	margin-left: $size * -1; // in this case, half the width of the arrow
+}
+
+/// Styles for arrow pointing up
+///
+/// @param {Color} $color [#333333]
+/// @param {Number} $size [8px]
+@mixin oHeaderUpArrow($color: #333333, $size: 8px) {
+	@include oHeaderArrow($size);
+	border-bottom: $size solid $color;
+	bottom: -1px; // Extra pixel ensures background and arrow have no space between them
+	left: 50%;
+	margin-left: $size * -2; // in this case, the width of the arrow
+}
+
+/// Helper function for assets
+@function oHeaderAsset($asset) {
+	@return oAssetsResolve($asset, o-header);
+}
+
+/// Target both IE8 and modern browsers at the M layout
+@mixin _oHeaderBreakpoint {
+	@include oGridRespondTo($o-header-breakpoint) {
+		@content;
+	}
+	@include oGridTargetIE8 {
+		@content;
+	}
+}

--- a/src/scss/_header_mixins.scss
+++ b/src/scss/_header_mixins.scss
@@ -1,7 +1,7 @@
 /// Default arrow styling
 ///
 /// @param {Number} $size [8px]
-@mixin oHeaderArrow($size: 8px) {
+@mixin oTechdocsHeaderArrow($size: 8px) {
 	border-left: $size solid transparent;
 	border-right: $size solid transparent;
 	width: 0;
@@ -16,8 +16,8 @@
 ///
 /// @param {Color} $color [#333333]
 /// @param {Number} $size [8px]
-@mixin oHeaderDownArrow($color: #333333, $size: 8px) {
-	@include oHeaderArrow($size);
+@mixin oTechdocsHeaderDownArrow($color: #333333, $size: 8px) {
+	@include oTechdocsHeaderArrow($size);
 	border-top: $size solid $color;
 	top: 100%;
 	margin-top: -1px; // Extra pixel ensures background and arrow have no space between them
@@ -29,8 +29,8 @@
 ///
 /// @param {Color} $color [#333333]
 /// @param {Number} $size [8px]
-@mixin oHeaderUpArrow($color: #333333, $size: 8px) {
-	@include oHeaderArrow($size);
+@mixin oTechdocsHeaderUpArrow($color: #333333, $size: 8px) {
+	@include oTechdocsHeaderArrow($size);
 	border-bottom: $size solid $color;
 	bottom: -1px; // Extra pixel ensures background and arrow have no space between them
 	left: 50%;
@@ -38,13 +38,13 @@
 }
 
 /// Helper function for assets
-@function oHeaderAsset($asset) {
-	@return oAssetsResolve($asset, o-header);
+@function oTechdocsHeaderAsset($asset) {
+	@return oAssetsResolve($asset, o-techdocs-header);
 }
 
 /// Target both IE8 and modern browsers at the M layout
-@mixin _oHeaderBreakpoint {
-	@include oGridRespondTo($o-header-breakpoint) {
+@mixin _oTechdocsHeaderBreakpoint {
+	@include oGridRespondTo($o-techdocs-header-breakpoint) {
 		@content;
 	}
 	@include oGridTargetIE8 {

--- a/src/scss/_header_theme_primary.scss
+++ b/src/scss/_header_theme_primary.scss
@@ -1,0 +1,51 @@
+.o-header__nav--primary-theme {
+	@include oHierarchicalNavHorizontalTheme;
+	text-align: right;
+	// Used in core experience so hidden elements don't continue appearing
+	overflow: hidden;
+
+	li {
+		text-align: left;
+
+		&[aria-controls][aria-expanded="true"]:after {
+			// CSS arrow for mega-dropdowns
+			@include oHeaderUpArrow(oColorsGetColorFor(o-header-product-brand product-brand, background));
+			z-index: $_o-hierarchical-nav-mega-dropdown-zindex+1;
+		}
+	}
+
+	a {
+		padding-right: oGridGutter();
+		padding-left: oGridGutter();
+		font-size: 14px;
+	}
+
+	// scss-lint:disable SelectorDepth
+	[data-o-hierarchical-nav-level='1'] > li {
+		// Default styling for the a tag
+		> a {
+			text-transform: uppercase;
+			font-weight: normal;
+			line-height: 50px;
+			height: 100%;
+		}
+
+		// Styling for the a tag in a selected state
+		&[aria-selected="true"] > a,
+		&[aria-controls][aria-expanded="true"] > a {
+			color: oColorsGetColorFor(o-header-item, text);
+			opacity: 0.7;
+		}
+	}
+	// scss-lint:enable SelectorDepth
+
+	// Padding for all a tags that aren't in the first hierarchical nav level
+	[data-o-hierarchical-nav-level] [data-o-hierarchical-nav-level] a {
+		padding: 14px oGridGutter();
+	}
+}
+
+// Set extra top positioning so that the secondary container with the brand colour can be seen
+.o-header__mega-dropdown--primary.o-hierarchical-nav__mega-dropdown {
+	top: 100%;
+}

--- a/src/scss/_header_theme_primary.scss
+++ b/src/scss/_header_theme_primary.scss
@@ -4,6 +4,10 @@
 	// Used in core experience so hidden elements don't continue appearing
 	overflow: hidden;
 
+	[data-o-hierarchical-nav-level] {
+		background-color: oColorsGetColorFor(o-techdocs-header, background);
+	}
+
 	li {
 		text-align: left;
 

--- a/src/scss/_header_theme_primary.scss
+++ b/src/scss/_header_theme_primary.scss
@@ -1,4 +1,4 @@
-.o-header__nav--primary-theme {
+.o-techdocs-header__nav--primary-theme {
 	@include oHierarchicalNavHorizontalTheme;
 	text-align: right;
 	// Used in core experience so hidden elements don't continue appearing
@@ -9,7 +9,7 @@
 
 		&[aria-controls][aria-expanded="true"]:after {
 			// CSS arrow for mega-dropdowns
-			@include oHeaderUpArrow(oColorsGetColorFor(o-header-product-brand product-brand, background));
+			@include oTechdocsHeaderUpArrow(oColorsGetColorFor(o-techdocs-header-product-brand product-brand, background));
 			z-index: $_o-hierarchical-nav-mega-dropdown-zindex+1;
 		}
 	}
@@ -33,7 +33,7 @@
 		// Styling for the a tag in a selected state
 		&[aria-selected="true"] > a,
 		&[aria-controls][aria-expanded="true"] > a {
-			color: oColorsGetColorFor(o-header-item, text);
+			color: oColorsGetColorFor(o-techdocs-header-item, text);
 			opacity: 0.7;
 		}
 	}
@@ -46,6 +46,6 @@
 }
 
 // Set extra top positioning so that the secondary container with the brand colour can be seen
-.o-header__mega-dropdown--primary.o-hierarchical-nav__mega-dropdown {
+.o-techdocs-header__mega-dropdown--primary.o-hierarchical-nav__mega-dropdown {
 	top: 100%;
 }

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -9,13 +9,3 @@
 		color: oColorsGetColorFor(link, text);
 	}
 }
-
-/// Target both IE8 and modern browsers at the M layout
-@mixin _oTechdocsHeaderBreakpoint {
-	@include oGridRespondTo($o-techdocs-header-breakpoint) {
-		@content;
-	}
-	@include oGridTargetIE8 {
-		@content;
-	}
-}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -9,3 +9,13 @@
 		color: oColorsGetColorFor(link, text);
 	}
 }
+
+/// Target both IE8 and modern browsers at the M layout
+@mixin _oHeaderBreakpoint {
+	@include oGridRespondTo($o-header-breakpoint) {
+		@content;
+	}
+	@include oGridTargetIE8 {
+		@content;
+	}
+}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -11,8 +11,8 @@
 }
 
 /// Target both IE8 and modern browsers at the M layout
-@mixin _oHeaderBreakpoint {
-	@include oGridRespondTo($o-header-breakpoint) {
+@mixin _oTechdocsHeaderBreakpoint {
+	@include oGridRespondTo($o-techdocs-header-breakpoint) {
 		@content;
 	}
 	@include oGridTargetIE8 {

--- a/src/scss/_page.scss
+++ b/src/scss/_page.scss
@@ -1,10 +1,8 @@
 // scss-lint:disable QualifyingElement
 .o-techdocs {
 	background-color: oColorsGetPaletteColor('white');
+	font-family: Helvetica, Arial ,sans-serif;
 
-	.o-header {
-		margin-bottom: 45px;
-	}
 	[aria-hidden=true] {
 		display: none;
 	}


### PR DESCRIPTION
This PR takes o-header at v4 and puts it into o-techdocs.

o-header v5 is redesigned to be consumer facing and is addressing different needs to those of a techdocs user/reader. This PR takes o-header v4 and puts it into o-techdocs so we don't have to maintain two separate versions of o-header.

There shouldn't be any visible difference to o-techdocs users, though they will need to change some class names to upgrade.

#55 