### PR TITLE
Add pa11y

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,9 +6,14 @@ machine:
 dependencies:
   override:
     - obt install
+    - npm install -g pa11y@^4
   cache_directories:
     - "node_modules"
 test:
   override:
     - obt test
     - obt verify
+    - "obt demo --runServer":
+        background: true
+    - sleep 10
+    - pa11y http://localhost:8080/demos/local/demo.html --ignore notice --ignore warning


### PR DESCRIPTION
Pa11y is an accessibility helper that will catch automatable errors (like images
without titles, or poor colour contrast)

This commit:

- Configures circle to run Pa11y by
-- Installing it
-- Running the demo server
-- Running pa11y against the demo

```
- "obt demo --runServer": # Run the demos
    background: true # Run them in the background
- sleep 10 # Give obt time to spin up the server
- pa11y http://localhost:8080/demos/local/demo.html --ignore notice --ignore warning # Run Pa11y against the demos
```

(I have a fix for all these failing pally tests in another branch...)