### PR TITLE
Prepend the base URL to permalinks and navigation

### DIFF
--- a/src/js/base-url.js
+++ b/src/js/base-url.js
@@ -1,0 +1,15 @@
+
+let baseUrl;
+
+/**
+ * Get the base URL of the document
+ */
+export function getBaseUrl(cache = true) {
+	if (cache && baseUrl) {
+		return baseUrl;
+	}
+	// We need to get rid of anything after the first hash in the URL,
+	// or we'll just keep adding hashes to the end when we navigate
+	baseUrl = document.baseURI.split('#').shift();
+	return baseUrl;
+}

--- a/src/js/nav.js
+++ b/src/js/nav.js
@@ -4,6 +4,7 @@
  *
  */
 
+import {getBaseUrl} from './base-url';
 import oViewport from 'o-viewport';
 
 oViewport.listenTo('scroll');
@@ -28,7 +29,7 @@ function nav() {
 	// Find heading 2s and build a link list.  Only proceed if there would be more than one item in the list
 	[].slice.call(qsa('.o-techdocs-content h2[id]')).forEach(function(el) {
 		headings.push({id:el.id, pos:offset(el)});
-		lis.push('<li id="o-techdocs-pagenav-'+el.id+'"><a href="#'+el.id+'">'+el.innerHTML+'</a></li>');
+		lis.push('<li id="o-techdocs-pagenav-' + el.id + '"><a href="' + getBaseUrl() + '#' + el.id + '">' + el.innerHTML + '</a></li>');
 	});
 	if (lis.length < 2) {
 		return;

--- a/src/js/permalinks.js
+++ b/src/js/permalinks.js
@@ -2,6 +2,8 @@
  * Show permalink markers on headings with an ID
  */
 
+import {getBaseUrl} from './base-url';
+
 export function permalinks() {
 	if (!document.querySelector('.o-techdocs-content')) {
 		return;
@@ -12,7 +14,7 @@ export function permalinks() {
 		return el.id;
 	}).forEach(function(el) {
 		const a = document.createElement('a');
-		a.href = "#"+el.id;
+		a.href = getBaseUrl() + '#' + el.id;
 		a.className = "o-techdocs__permalink";
 		a.title = "Link directly to this section of the page";
 		a.innerHTML = "&#x00B6;";

--- a/test/base-url.test.js
+++ b/test/base-url.test.js
@@ -1,0 +1,75 @@
+/* eslint-env mocha, sinon, proclaim */
+
+import {getBaseUrl} from './../src/js/base-url';
+import * as assert from 'proclaim';
+import sinon from 'sinon/pkg/sinon';
+
+sinon.assert.expose(assert, {
+	includeFail: false,
+	prefix: ''
+});
+
+describe('base-url', () => {
+	let testArea;
+
+	before(() => {
+		document.body.innerHTML += '<div id="test-area"></div>';
+		testArea = document.getElementById('test-area');
+	});
+
+	afterEach(() => {
+		testArea.innerHTML = '';
+		[...document.head.querySelectorAll('base')].map(base => base.remove());
+	});
+
+	describe('getBaseUrl()', () => {
+
+		it('returns the baseURI of the document', () => {
+			assert.strictEqual(getBaseUrl(false), document.baseURI);
+		});
+
+		describe('when a base element is present (and is set to an absolute URL)', () => {
+
+			beforeEach(() => {
+				const base = document.createElement('base');
+				base.setAttribute('href', '/foo/bar');
+				document.head.appendChild(base);
+			});
+
+			it('returns the base element href resolved against the current URL', () => {
+				assert.strictEqual(getBaseUrl(false), `${window.location.protocol}//${window.location.host}/foo/bar`);
+			});
+
+		});
+
+		describe('when a base element is present (and is set to a relative URL)', () => {
+
+			beforeEach(() => {
+				const base = document.createElement('base');
+				base.setAttribute('href', 'foo');
+				document.head.appendChild(base);
+			});
+
+			it('returns the base element href resolved against the current URL', () => {
+				assert.strictEqual(getBaseUrl(false), `${window.location.protocol}//${window.location.host}/foo`);
+			});
+
+		});
+
+		describe('when a base element is present (and contains hashes)', () => {
+
+			beforeEach(() => {
+				const base = document.createElement('base');
+				base.setAttribute('href', 'foo#bar#baz');
+				document.head.appendChild(base);
+			});
+
+			it('returns the base element href resolved against the current URL with hashes removed', () => {
+				assert.strictEqual(getBaseUrl(false), `${window.location.protocol}//${window.location.host}/foo`);
+			});
+
+		});
+
+	});
+
+});


### PR DESCRIPTION
Currently all permalinks and in-page links in the sidebar don't work
correctly if the document contains a `<base/>` element. This updates the
code for those to prepend the element IDs with the base URL.

We use `<base/>` extensively across the services, and currently have to
work around this behaviour.