### PR TITLE
Remove superfluous calc

### DIFF
--- a/src/scss/_content.scss
+++ b/src/scss/_content.scss
@@ -19,7 +19,7 @@
 		font-size: 26px;
 		$border-thickness: 4px;
 		border-bottom: $border-thickness solid $o-techdocs-border-color;
-		padding-bottom: calc(oTechdocsSpacingUnit() - $border-thickness);
+		padding-bottom: oTechdocsSpacingUnit(1) - $border-thickness;
 		margin-bottom: oTechdocsSpacingUnit(2);
 		margin-top: oTechdocsSpacingUnit(5);
 	}

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,5 +1,5 @@
 $o-techdocs-spacing-unit: 8;
 
-@function oTechdocsSpacingUnit($multiplier) {
+@function oTechdocsSpacingUnit($multiplier:1) {
 	@return $o-techdocs-spacing-unit * $multiplier + 0px;
 }

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,5 +1,5 @@
 $o-techdocs-spacing-unit: 8;
 
-@function oTechdocsSpacingUnit($multiplier:1) {
+@function oTechdocsSpacingUnit($multiplier: 1) {
 	@return $o-techdocs-spacing-unit * $multiplier + 0px;
 }


### PR DESCRIPTION
Currently the value of the padding-bottom property is invalid due to the fact that the calc function is output in the CSS which does not understand sass functions and variables `calc(oTechdocsSpacingUnit() - $border-thickness)`. This means that the computed value of the padding-bottom property is whatever the default value the user agent has decided to go with. Chrome goes with `0px`.

The values used in the calc are static, meaning that we can remove the calc call and let this be done by the preprocessor.

Removing the calc call surfaced the fact that the function requires an argument. The argument could be `0` but that would make the resulting value become `-4px` and negative values are not allowed on padding. When the argument is `1` then the resulting values becomes `4px`.