### PR TITLE
Use the new $default-branch macro instead of hardcoding the branch name

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,3 @@
-"use strict"
-
 module.exports = {
-    extends: "origami-component"
+	extends: "origami-component"
 };

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -7,7 +7,7 @@ on:
       - reopened
       - synchronize
   push:
-    branches: master
+    branches: $default-branch
 jobs:
   percy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will help with any future work on renaming the default branch name.