### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,10 +1,10 @@
 
-import highlight from './src/js/highlight';
-import { nav } from './src/js/nav';
-import { tables } from './src/js/tables';
-import { reveals } from './src/js/reveals';
-import { permalinks } from './src/js/permalinks';
-import { gistIt } from './src/js/gist-it';
+import highlight from './src/js/highlight.js';
+import { nav } from './src/js/nav.js';
+import { tables } from './src/js/tables.js';
+import { reveals } from './src/js/reveals.js';
+import { permalinks } from './src/js/permalinks.js';
+import { gistIt } from './src/js/gist-it.js';
 
 const techdocsModules = [
 	highlight,


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing